### PR TITLE
Fix castle rights bug in move executor

### DIFF
--- a/src/moveexecutor.cpp
+++ b/src/moveexecutor.cpp
@@ -72,7 +72,7 @@ void MoveExecutor::operator()(Square *from, Square *to, GameState& gameState, bo
         state.m_captured.reset();
 
     state.m_kingSideCastleRight &= !(isKing || (isRook && from->col() == 7));
-    state.m_kingSideCastleRight &= !(isKing || (isRook && from->col() == 0));
+    state.m_queenSideCastleRight &= !(isKing || (isRook && from->col() == 0));
 
     if (isKing)
         state.m_king = to;


### PR DESCRIPTION
## Summary
- correct update of queen-side castle right when a rook or king moves

## Testing
- `cmake ..` *(fails: Qt6 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68407b7277b483339e719aae9092b35c