### PR TITLE
Fix repetition typo

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -174,12 +174,12 @@ void Controller::handleGameOutCome(Validator::GameOutcome outCome)
         emit gameOver("Stalemate! Would you like to start a new game?");
         return;
     case Validator::DrawByRepetition:
-        emit gameOver("Draw by repitition! "
-                      "Would you like to start a new game?");
+        emit gameOver(
+            "Draw by repetition! Would you like to start a new game?");
         return;
     case Validator::DrawBy50MoveRule:
-        emit gameOver("Draw by the rule of fifty moves! "
-                      "Would you like to start a new game?");
+        emit gameOver(
+            "Draw by the rule of fifty moves! Would you like to start a new game?");
         return;
     }
 }


### PR DESCRIPTION
## Summary
- fix repetition typo in `src/controller.cpp`
- unify draw messages into single strings

## Testing
- `grep -R repit src qml | cat`
- `grep -Rin repitition . || true`


------
https://chatgpt.com/codex/tasks/task_e_68407cc678b88333b699e41f61c6b3aa