### PR TITLE
Show captured pieces

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -28,12 +28,13 @@ Window {
     title: "Chess"
     visible: true
     width: 400
-    height: 400
+    height: 480
+    property int capSpace: 80
     onWidthChanged: {
-        height = width
+        height = width + capSpace
     }
     onHeightChanged: {
-        width = height
+        width = height - capSpace
     }
 
     BasicTheme {id: theme}

--- a/qml/components/BasicTheme.qml
+++ b/qml/components/BasicTheme.qml
@@ -17,6 +17,7 @@ Item {
     // board BoardContainer
     property string containerColor      : "#b09030"
     property string borderColor         : "#404020"
+    property string captureValueColor   : "white"
 
     // font
     FontLoader {

--- a/qml/components/BasicTheme.qml
+++ b/qml/components/BasicTheme.qml
@@ -17,7 +17,6 @@ Item {
     // board BoardContainer
     property string containerColor      : "#b09030"
     property string borderColor         : "#404020"
-    property string captureValueColor   : "white"
 
     // font
     FontLoader {

--- a/qml/components/BoardContainer.qml
+++ b/qml/components/BoardContainer.qml
@@ -21,6 +21,7 @@ Rectangle {
                                      : Controller.blackCapturePieces
             font.pixelSize: captureSize
             font.family: theme.chessFont
+            anchors.verticalCenter: parent.verticalCenter
         }
         Text {
             text: {
@@ -29,8 +30,9 @@ Rectangle {
                 return v > 0 ? "+" + v : "";
             }
             font.pixelSize: captureSize * 0.5
-            color: theme.lightSquare
+            color: theme.captureValueColor
             verticalAlignment: Text.AlignVCenter
+            anchors.verticalCenter: parent.verticalCenter
         }
     }
 
@@ -64,6 +66,7 @@ Rectangle {
                                      : Controller.whiteCapturePieces
             font.pixelSize: captureSize
             font.family: theme.chessFont
+            anchors.verticalCenter: parent.verticalCenter
         }
         Text {
             text: {
@@ -72,8 +75,9 @@ Rectangle {
                 return v > 0 ? "+" + v : "";
             }
             font.pixelSize: captureSize * 0.5
-            color: theme.lightSquare
+            color: theme.captureValueColor
             verticalAlignment: Text.AlignVCenter
+            anchors.verticalCenter: parent.verticalCenter
         }
     }
 }

--- a/qml/components/BoardContainer.qml
+++ b/qml/components/BoardContainer.qml
@@ -5,17 +5,20 @@ Rectangle {
     anchors.fill: parent
     color: theme.containerColor
     property int borderMargin: 10
-    property real borderSize: Math.min(
+    property int spacing: 4
+    property real boardSize: Math.min(
         boardContainer.width  - borderMargin*2,
         boardContainer.height - borderMargin*2
+            - topCaptures.implicitHeight - bottomCaptures.implicitHeight
+            - spacing*2
     )
 
     Text {
         id: topCaptures
-        anchors.bottom: boardBorder.top
-        anchors.left: boardBorder.left
-        anchors.right: boardBorder.right
-        anchors.bottomMargin: 4
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.topMargin: borderMargin
         horizontalAlignment: Text.AlignHCenter
         text: Controller.flipped ? Controller.whiteCaptures
                                   : Controller.blackCaptures
@@ -25,14 +28,15 @@ Rectangle {
 
     Rectangle {
         id: boardBorder
-        x: borderMargin
-        y: borderMargin
-        width:  borderSize
-        height: borderSize
+        width: boardSize
+        height: boardSize
         color: theme.borderColor
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: topCaptures.bottom
+        anchors.topMargin: spacing
         Item {
             id: boardWrapper
-            anchors.fill: boardBorder
+            anchors.fill: parent
             anchors.margins: 1
             Board {}
         }
@@ -41,9 +45,11 @@ Rectangle {
     Text {
         id: bottomCaptures
         anchors.top: boardBorder.bottom
-        anchors.left: boardBorder.left
-        anchors.right: boardBorder.right
-        anchors.topMargin: 4
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.topMargin: spacing
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: borderMargin
         horizontalAlignment: Text.AlignHCenter
         text: Controller.flipped ? Controller.blackCaptures
                                  : Controller.whiteCaptures

--- a/qml/components/BoardContainer.qml
+++ b/qml/components/BoardContainer.qml
@@ -28,8 +28,9 @@ Rectangle {
                                              : Controller.blackCaptureValue;
                 return v > 0 ? "+" + v : "";
             }
-            font.pixelSize: captureSize * 0.6
+            font.pixelSize: captureSize * 0.5
             color: theme.lightSquare
+            verticalAlignment: Text.AlignVCenter
         }
     }
 
@@ -70,8 +71,9 @@ Rectangle {
                                              : Controller.whiteCaptureValue;
                 return v > 0 ? "+" + v : "";
             }
-            font.pixelSize: captureSize * 0.6
+            font.pixelSize: captureSize * 0.5
             color: theme.lightSquare
+            verticalAlignment: Text.AlignVCenter
         }
     }
 }

--- a/qml/components/BoardContainer.qml
+++ b/qml/components/BoardContainer.qml
@@ -28,7 +28,8 @@ Rectangle {
                                              : Controller.blackCaptureValue;
                 return v > 0 ? "+" + v : "";
             }
-            font.pixelSize: captureSize
+            font.pixelSize: captureSize * 0.6
+            color: theme.lightSquare
         }
     }
 
@@ -69,7 +70,8 @@ Rectangle {
                                              : Controller.whiteCaptureValue;
                 return v > 0 ? "+" + v : "";
             }
-            font.pixelSize: captureSize
+            font.pixelSize: captureSize * 0.6
+            color: theme.lightSquare
         }
     }
 }

--- a/qml/components/BoardContainer.qml
+++ b/qml/components/BoardContainer.qml
@@ -7,6 +7,7 @@ Rectangle {
     property int borderMargin: 10
     property int spacing: 4
     property real boardSize: boardContainer.width - borderMargin*2
+    property real captureSize: boardSize / 8 * 0.8
 
     Row {
         id: topCaptures
@@ -14,10 +15,11 @@ Rectangle {
         anchors.left: boardBorder.left
         anchors.topMargin: borderMargin
         spacing: 2
+        height: captureSize
         Text {
             text: Controller.flipped ? Controller.whiteCapturePieces
                                      : Controller.blackCapturePieces
-            font.pixelSize: boardBorder.width / 8 * 0.8
+            font.pixelSize: captureSize
             font.family: theme.chessFont
         }
         Text {
@@ -26,7 +28,7 @@ Rectangle {
                                              : Controller.blackCaptureValue;
                 return v > 0 ? "+" + v : "";
             }
-            font.pixelSize: boardBorder.width / 8 * 0.8
+            font.pixelSize: captureSize
         }
     }
 
@@ -54,10 +56,11 @@ Rectangle {
         anchors.bottom: parent.bottom
         anchors.bottomMargin: borderMargin
         spacing: 2
+        height: captureSize
         Text {
             text: Controller.flipped ? Controller.blackCapturePieces
                                      : Controller.whiteCapturePieces
-            font.pixelSize: boardBorder.width / 8 * 0.8
+            font.pixelSize: captureSize
             font.family: theme.chessFont
         }
         Text {
@@ -66,7 +69,7 @@ Rectangle {
                                              : Controller.whiteCaptureValue;
                 return v > 0 ? "+" + v : "";
             }
-            font.pixelSize: boardBorder.width / 8 * 0.8
+            font.pixelSize: captureSize
         }
     }
 }

--- a/qml/components/BoardContainer.qml
+++ b/qml/components/BoardContainer.qml
@@ -30,7 +30,7 @@ Rectangle {
                 return v > 0 ? "+" + v : "";
             }
             font.pixelSize: captureSize * 0.5
-            color: theme.captureValueColor
+            color: Controller.flipped ? theme.darkSquare : theme.lightSquare
             verticalAlignment: Text.AlignVCenter
             anchors.verticalCenter: parent.verticalCenter
         }
@@ -75,7 +75,7 @@ Rectangle {
                 return v > 0 ? "+" + v : "";
             }
             font.pixelSize: captureSize * 0.5
-            color: theme.captureValueColor
+            color: Controller.flipped ? theme.lightSquare : theme.darkSquare
             verticalAlignment: Text.AlignVCenter
             anchors.verticalCenter: parent.verticalCenter
         }

--- a/qml/components/BoardContainer.qml
+++ b/qml/components/BoardContainer.qml
@@ -6,12 +6,7 @@ Rectangle {
     color: theme.containerColor
     property int borderMargin: 10
     property int spacing: 4
-    property real boardSize: Math.min(
-        boardContainer.width  - borderMargin*2,
-        boardContainer.height - borderMargin*2
-            - topCaptures.implicitHeight - bottomCaptures.implicitHeight
-            - spacing*2
-    )
+    property real boardSize: boardContainer.width - borderMargin*2
 
     Text {
         id: topCaptures

--- a/qml/components/BoardContainer.qml
+++ b/qml/components/BoardContainer.qml
@@ -16,10 +16,10 @@ Rectangle {
     Text {
         id: topCaptures
         anchors.top: parent.top
-        anchors.left: parent.left
-        anchors.right: parent.right
+        anchors.left: boardBorder.left
         anchors.topMargin: borderMargin
-        horizontalAlignment: Text.AlignHCenter
+        anchors.leftMargin: 0
+        horizontalAlignment: Text.AlignLeft
         text: Controller.flipped ? Controller.whiteCaptures
                                   : Controller.blackCaptures
         font.pixelSize: boardBorder.width / 8 * 0.8
@@ -45,12 +45,11 @@ Rectangle {
     Text {
         id: bottomCaptures
         anchors.top: boardBorder.bottom
-        anchors.left: parent.left
-        anchors.right: parent.right
+        anchors.right: boardBorder.right
         anchors.topMargin: spacing
         anchors.bottom: parent.bottom
         anchors.bottomMargin: borderMargin
-        horizontalAlignment: Text.AlignHCenter
+        horizontalAlignment: Text.AlignRight
         text: Controller.flipped ? Controller.blackCaptures
                                  : Controller.whiteCaptures
         font.pixelSize: boardBorder.width / 8 * 0.8

--- a/qml/components/BoardContainer.qml
+++ b/qml/components/BoardContainer.qml
@@ -8,17 +8,26 @@ Rectangle {
     property int spacing: 4
     property real boardSize: boardContainer.width - borderMargin*2
 
-    Text {
+    Row {
         id: topCaptures
         anchors.top: parent.top
         anchors.left: boardBorder.left
         anchors.topMargin: borderMargin
-        anchors.leftMargin: 0
-        horizontalAlignment: Text.AlignLeft
-        text: Controller.flipped ? Controller.whiteCaptures
-                                  : Controller.blackCaptures
-        font.pixelSize: boardBorder.width / 8 * 0.8
-        font.family: theme.chessFont
+        spacing: 2
+        Text {
+            text: Controller.flipped ? Controller.whiteCapturePieces
+                                     : Controller.blackCapturePieces
+            font.pixelSize: boardBorder.width / 8 * 0.8
+            font.family: theme.chessFont
+        }
+        Text {
+            text: {
+                const v = Controller.flipped ? Controller.whiteCaptureValue
+                                             : Controller.blackCaptureValue;
+                return v > 0 ? "+" + v : "";
+            }
+            font.pixelSize: boardBorder.width / 8 * 0.8
+        }
     }
 
     Rectangle {
@@ -37,17 +46,27 @@ Rectangle {
         }
     }
 
-    Text {
+    Row {
         id: bottomCaptures
         anchors.top: boardBorder.bottom
         anchors.right: boardBorder.right
         anchors.topMargin: spacing
         anchors.bottom: parent.bottom
         anchors.bottomMargin: borderMargin
-        horizontalAlignment: Text.AlignRight
-        text: Controller.flipped ? Controller.blackCaptures
-                                 : Controller.whiteCaptures
-        font.pixelSize: boardBorder.width / 8 * 0.8
-        font.family: theme.chessFont
+        spacing: 2
+        Text {
+            text: Controller.flipped ? Controller.blackCapturePieces
+                                     : Controller.whiteCapturePieces
+            font.pixelSize: boardBorder.width / 8 * 0.8
+            font.family: theme.chessFont
+        }
+        Text {
+            text: {
+                const v = Controller.flipped ? Controller.blackCaptureValue
+                                             : Controller.whiteCaptureValue;
+                return v > 0 ? "+" + v : "";
+            }
+            font.pixelSize: boardBorder.width / 8 * 0.8
+        }
     }
 }

--- a/qml/components/BoardContainer.qml
+++ b/qml/components/BoardContainer.qml
@@ -10,6 +10,19 @@ Rectangle {
         boardContainer.height - borderMargin*2
     )
 
+    Text {
+        id: topCaptures
+        anchors.bottom: boardBorder.top
+        anchors.left: boardBorder.left
+        anchors.right: boardBorder.right
+        anchors.bottomMargin: 4
+        horizontalAlignment: Text.AlignHCenter
+        text: Controller.flipped ? Controller.whiteCaptures
+                                  : Controller.blackCaptures
+        font.pixelSize: boardBorder.width / 8 * 0.8
+        font.family: theme.chessFont
+    }
+
     Rectangle {
         id: boardBorder
         x: borderMargin
@@ -23,5 +36,18 @@ Rectangle {
             anchors.margins: 1
             Board {}
         }
+    }
+
+    Text {
+        id: bottomCaptures
+        anchors.top: boardBorder.bottom
+        anchors.left: boardBorder.left
+        anchors.right: boardBorder.right
+        anchors.topMargin: 4
+        horizontalAlignment: Text.AlignHCenter
+        text: Controller.flipped ? Controller.blackCaptures
+                                 : Controller.whiteCaptures
+        font.pixelSize: boardBorder.width / 8 * 0.8
+        font.family: theme.chessFont
     }
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -38,6 +38,38 @@ QList<QChar> promotionChoices (Pieces::Color color)
                 Pieces::WhiteKnight,
                 Pieces::WhiteBishop};
 }
+
+int captureValue(QChar p) noexcept
+{
+    switch (ushort(p.unicode())) {
+    case Pieces::WhiteQueenCode:
+    case Pieces::BlackQueenCode:
+        return 5;
+    case Pieces::WhiteRookCode:
+    case Pieces::BlackRookCode:
+        return 4;
+    case Pieces::WhiteBishopCode:
+    case Pieces::BlackBishopCode:
+        return 3;
+    case Pieces::WhiteKnightCode:
+    case Pieces::BlackKnightCode:
+        return 2;
+    case Pieces::WhitePawnCode:
+    case Pieces::BlackPawnCode:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+QString sortedCaptures(const QString& list)
+{
+    QString s = list;
+    std::sort(s.begin(), s.end(), [](const QChar& a, const QChar& b){
+        return captureValue(a) > captureValue(b);
+    });
+    return s;
+}
 }
 
 Controller::Controller(QObject *parent) :
@@ -189,39 +221,6 @@ void Controller::handleGameOutCome(Validator::GameOutcome outCome)
     }
 }
 
-namespace {
-int captureValue(QChar p) noexcept
-{
-    switch (ushort(p.unicode())) {
-    case Pieces::WhiteQueenCode:
-    case Pieces::BlackQueenCode:
-        return 5;
-    case Pieces::WhiteRookCode:
-    case Pieces::BlackRookCode:
-        return 4;
-    case Pieces::WhiteBishopCode:
-    case Pieces::BlackBishopCode:
-        return 3;
-    case Pieces::WhiteKnightCode:
-    case Pieces::BlackKnightCode:
-        return 2;
-    case Pieces::WhitePawnCode:
-    case Pieces::BlackPawnCode:
-        return 1;
-    default:
-        return 0;
-    }
-}
-
-QString sortedCaptures(const QString& list)
-{
-    QString s = list;
-    std::sort(s.begin(), s.end(), [](const QChar& a, const QChar& b){
-        return captureValue(a) > captureValue(b);
-    });
-    return s;
-}
-}
 
 QString Controller::whiteCaptures() const noexcept
 {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -71,17 +71,24 @@ QString sortedCaptures(QString s)
     return s;
 }
 
-QString showCaptures(QString list)
+QString capturePieces(QString list)
+{
+    list = sortedCaptures(std::move(list));
+    if (list.size() > 5)
+        list.truncate(5);
+    return list;
+}
+
+int captureRemainder(QString list)
 {
     list = sortedCaptures(std::move(list));
     if (list.size() <= 5)
-        return list;
+        return 0;
 
     int rest = 0;
     for (int i = 5; i < list.size(); ++i)
         rest += captureValue(list.at(i));
-    list.truncate(5);
-    return list + QLatin1Char(' ') + QLatin1Char('+') + QString::number(rest);
+    return rest;
 }
 }
 
@@ -235,12 +242,22 @@ void Controller::handleGameOutCome(Validator::GameOutcome outCome)
 }
 
 
-QString Controller::whiteCaptures() const noexcept
+QString Controller::whiteCapturePieces() const noexcept
 {
-    return showCaptures(m_state.m_white.m_captures);
+    return capturePieces(m_state.m_white.m_captures);
 }
 
-QString Controller::blackCaptures() const noexcept
+int Controller::whiteCaptureValue() const noexcept
 {
-    return showCaptures(m_state.m_black.m_captures);
+    return captureRemainder(m_state.m_white.m_captures);
+}
+
+QString Controller::blackCapturePieces() const noexcept
+{
+    return capturePieces(m_state.m_black.m_captures);
+}
+
+int Controller::blackCaptureValue() const noexcept
+{
+    return captureRemainder(m_state.m_black.m_captures);
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -71,19 +71,23 @@ QString sortedCaptures(QString s)
     return s;
 }
 
+constexpr int kDisplayedCaptures = 5;
+
 QString capturePieces(QString list)
 {
     list = sortedCaptures(std::move(list));
-    if (list.size() > 5)
-        list.truncate(5);
+    if (list.size() > kDisplayedCaptures)
+        list.truncate(kDisplayedCaptures);
     return list;
 }
 
 int captureRemainder(QString list)
 {
+    if (list.size() <= kDisplayedCaptures)
+        return 0;
     list = sortedCaptures(std::move(list));
     int rest = 0;
-    for (int i = 5; i < list.size(); ++i)
+    for (int i = kDisplayedCaptures; i < list.size(); ++i)
         rest += captureValue(list.at(i));
     return rest;
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -82,9 +82,6 @@ QString capturePieces(QString list)
 int captureRemainder(QString list)
 {
     list = sortedCaptures(std::move(list));
-    if (list.size() <= 5)
-        return 0;
-
     int rest = 0;
     for (int i = 5; i < list.size(); ++i)
         rest += captureValue(list.at(i));

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -63,13 +63,25 @@ int captureValue(QChar p) noexcept
     }
 }
 
-QString sortedCaptures(const QString& list)
+QString sortedCaptures(QString s)
 {
-    QString s = list;
     std::sort(s.begin(), s.end(), [](const QChar& a, const QChar& b){
         return captureValue(a) > captureValue(b);
     });
     return s;
+}
+
+QString showCaptures(QString list)
+{
+    list = sortedCaptures(std::move(list));
+    if (list.size() <= 5)
+        return list;
+
+    int rest = 0;
+    for (int i = 5; i < list.size(); ++i)
+        rest += captureValue(list.at(i));
+    list.truncate(5);
+    return list + QLatin1Char(' ') + QLatin1Char('+') + QString::number(rest);
 }
 }
 
@@ -225,10 +237,10 @@ void Controller::handleGameOutCome(Validator::GameOutcome outCome)
 
 QString Controller::whiteCaptures() const noexcept
 {
-    return sortedCaptures(m_state.m_white.m_captures);
+    return showCaptures(m_state.m_white.m_captures);
 }
 
 QString Controller::blackCaptures() const noexcept
 {
-    return sortedCaptures(m_state.m_black.m_captures);
+    return showCaptures(m_state.m_black.m_captures);
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -76,7 +76,10 @@ void Controller::selectOrMovePiece(int row, int col)
         return;
     }
     else if (m_from) {
+        const int prevCapCount = state.m_captures.size();
         m_moveExec(m_from, selected, m_state, m_flipped);
+        if (state.m_captures.size() != prevCapCount)
+            emit capturesChanged();
 
         if (const Square* p = state.m_promotedPawnSquare; p)
             emit promotePawn(p->row(), p->col(),
@@ -109,6 +112,7 @@ void Controller::restartGame(bool white)
     m_state = GameState{};
     m_state.m_white.m_king = m_board.at(7, 4);
     m_state.m_black.m_king = m_board.at(0, 4);
+    emit capturesChanged();
     if (!white) {
         flipBoard();
         m_state.switchTurn();

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -22,6 +22,7 @@
 
 #include "controller.h"
 #include "square.h"
+#include <algorithm>
 
 namespace {
 QList<QChar> promotionChoices (Pieces::Color color)
@@ -186,4 +187,48 @@ void Controller::handleGameOutCome(Validator::GameOutcome outCome)
                       "Would you like to start a new game?");
         return;
     }
+}
+
+namespace {
+int captureValue(QChar p) noexcept
+{
+    switch (ushort(p.unicode())) {
+    case Pieces::WhiteQueenCode:
+    case Pieces::BlackQueenCode:
+        return 5;
+    case Pieces::WhiteRookCode:
+    case Pieces::BlackRookCode:
+        return 4;
+    case Pieces::WhiteBishopCode:
+    case Pieces::BlackBishopCode:
+        return 3;
+    case Pieces::WhiteKnightCode:
+    case Pieces::BlackKnightCode:
+        return 2;
+    case Pieces::WhitePawnCode:
+    case Pieces::BlackPawnCode:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+QString sortedCaptures(const QString& list)
+{
+    QString s = list;
+    std::sort(s.begin(), s.end(), [](const QChar& a, const QChar& b){
+        return captureValue(a) > captureValue(b);
+    });
+    return s;
+}
+}
+
+QString Controller::whiteCaptures() const noexcept
+{
+    return sortedCaptures(m_state.m_white.m_captures);
+}
+
+QString Controller::blackCaptures() const noexcept
+{
+    return sortedCaptures(m_state.m_black.m_captures);
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -39,21 +39,22 @@ QList<QChar> promotionChoices (Pieces::Color color)
                 Pieces::WhiteBishop};
 }
 
+// sort captures by standard chess piece values
 int captureValue(QChar p) noexcept
 {
     switch (ushort(p.unicode())) {
     case Pieces::WhiteQueenCode:
     case Pieces::BlackQueenCode:
-        return 5;
+        return 9;  // queen
     case Pieces::WhiteRookCode:
     case Pieces::BlackRookCode:
-        return 4;
+        return 5;  // rook
     case Pieces::WhiteBishopCode:
     case Pieces::BlackBishopCode:
-        return 3;
+        return 3;  // bishop
     case Pieces::WhiteKnightCode:
     case Pieces::BlackKnightCode:
-        return 2;
+        return 3;  // knight
     case Pieces::WhitePawnCode:
     case Pieces::BlackPawnCode:
         return 1;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -25,6 +25,8 @@
 #include <algorithm>
 
 namespace {
+static constexpr int s_DisplayCaptures = 5;
+
 QList<QChar> promotionChoices (Pieces::Color color)
 {
     if (color == Pieces::Black)
@@ -71,23 +73,22 @@ QString sortedCaptures(QString s)
     return s;
 }
 
-constexpr int kDisplayedCaptures = 5;
 
 QString capturePieces(QString list)
 {
     list = sortedCaptures(std::move(list));
-    if (list.size() > kDisplayedCaptures)
-        list.truncate(kDisplayedCaptures);
+    if (list.size() > s_DisplayCaptures)
+        list.truncate(s_DisplayCaptures);
     return list;
 }
 
 int captureRemainder(QString list)
 {
-    if (list.size() <= kDisplayedCaptures)
+    if (list.size() <= s_DisplayCaptures)
         return 0;
     list = sortedCaptures(std::move(list));
     int rest = 0;
-    for (int i = kDisplayedCaptures; i < list.size(); ++i)
+    for (int i = s_DisplayCaptures; i < list.size(); ++i)
         rest += captureValue(list.at(i));
     return rest;
 }

--- a/src/controller.h
+++ b/src/controller.h
@@ -31,6 +31,7 @@
 #include <QObject>
 #include <qqmlintegration.h>
 #include <QSet>
+#include <QString>
 
 class Controller: public QObject
 {
@@ -39,6 +40,8 @@ class Controller: public QObject
     QML_ELEMENT
     Q_PROPERTY(Board* board READ board CONSTANT)
     Q_PROPERTY(bool flipped READ flipped WRITE setFlipped NOTIFY flippedChanged)
+    Q_PROPERTY(QString whiteCaptures READ whiteCaptures NOTIFY capturesChanged)
+    Q_PROPERTY(QString blackCaptures READ blackCaptures NOTIFY capturesChanged)
 
 public:
     Controller(QObject *parent = nullptr);
@@ -48,10 +51,13 @@ public:
     Board* board() const noexcept {return const_cast<Board*>(&m_board);}
     bool flipped() const noexcept {return m_flipped;}
     void setFlipped(bool val) {if (val != m_flipped) flipBoard();}
+    QString whiteCaptures() const noexcept { return m_state.m_white.m_captures; }
+    QString blackCaptures() const noexcept { return m_state.m_black.m_captures; }
 signals:
     void promotePawn(int row, int col, const QList<QChar>& choices);
     void gameOver(const QString message);
     void flippedChanged();
+    void capturesChanged();
 private:
     void flipBoard();
     void handleGameOutCome(Validator::GameOutcome outCome);

--- a/src/controller.h
+++ b/src/controller.h
@@ -51,8 +51,8 @@ public:
     Board* board() const noexcept {return const_cast<Board*>(&m_board);}
     bool flipped() const noexcept {return m_flipped;}
     void setFlipped(bool val) {if (val != m_flipped) flipBoard();}
-    QString whiteCaptures() const noexcept { return m_state.m_white.m_captures; }
-    QString blackCaptures() const noexcept { return m_state.m_black.m_captures; }
+    QString whiteCaptures() const noexcept;
+    QString blackCaptures() const noexcept;
 signals:
     void promotePawn(int row, int col, const QList<QChar>& choices);
     void gameOver(const QString message);

--- a/src/controller.h
+++ b/src/controller.h
@@ -40,8 +40,10 @@ class Controller: public QObject
     QML_ELEMENT
     Q_PROPERTY(Board* board READ board CONSTANT)
     Q_PROPERTY(bool flipped READ flipped WRITE setFlipped NOTIFY flippedChanged)
-    Q_PROPERTY(QString whiteCaptures READ whiteCaptures NOTIFY capturesChanged)
-    Q_PROPERTY(QString blackCaptures READ blackCaptures NOTIFY capturesChanged)
+    Q_PROPERTY(QString whiteCapturePieces READ whiteCapturePieces NOTIFY capturesChanged)
+    Q_PROPERTY(int whiteCaptureValue READ whiteCaptureValue NOTIFY capturesChanged)
+    Q_PROPERTY(QString blackCapturePieces READ blackCapturePieces NOTIFY capturesChanged)
+    Q_PROPERTY(int blackCaptureValue READ blackCaptureValue NOTIFY capturesChanged)
 
 public:
     Controller(QObject *parent = nullptr);
@@ -51,8 +53,10 @@ public:
     Board* board() const noexcept {return const_cast<Board*>(&m_board);}
     bool flipped() const noexcept {return m_flipped;}
     void setFlipped(bool val) {if (val != m_flipped) flipBoard();}
-    QString whiteCaptures() const noexcept;
-    QString blackCaptures() const noexcept;
+    QString whiteCapturePieces() const noexcept;
+    int whiteCaptureValue() const noexcept;
+    QString blackCapturePieces() const noexcept;
+    int blackCaptureValue() const noexcept;
 signals:
     void promotePawn(int row, int col, const QList<QChar>& choices);
     void gameOver(const QString message);

--- a/src/gamestate.h
+++ b/src/gamestate.h
@@ -23,6 +23,7 @@
 #ifndef GAMESTATE_H
 #define GAMESTATE_H
 #include <QList>
+#include <QString>
 #include "pieces.h"
 
 class Square;
@@ -34,7 +35,7 @@ struct PlayerState {
     // last move
     Square* m_enPassantTarget = nullptr;
     Square* m_promotedPawnSquare = nullptr;
-    std::optional<QChar> m_captured;
+    QString m_captures;
     // last moves
     int m_noPawnMoveOrCapture = 0;
     QList<std::pair<Square*, Square*>> m_moves;

--- a/src/moveexecutor.cpp
+++ b/src/moveexecutor.cpp
@@ -64,12 +64,13 @@ void MoveExecutor::operator()(Square *from, Square *to, GameState& gameState, bo
             state.m_promotedPawnSquare = to;
     }
 
+    QChar capturedPiece = Pieces::Empty;
     if (const QChar targetPiece = to->piece(); targetPiece != Pieces::Empty)
-        state.m_captured.emplace(targetPiece);
+        capturedPiece = targetPiece;
     else if (enPassant)
-        state.m_captured.emplace(isWhite? Pieces::BlackPawn:Pieces::WhitePawn);
-    else
-        state.m_captured.reset();
+        capturedPiece = isWhite ? Pieces::BlackPawn : Pieces::WhitePawn;
+    if (capturedPiece != Pieces::Empty)
+        state.m_captures.append(capturedPiece);
 
     state.m_kingSideCastleRight &= !(isKing || (isRook && from->col() == 7));
     state.m_kingSideCastleRight &= !(isKing || (isRook && from->col() == 0));
@@ -79,8 +80,8 @@ void MoveExecutor::operator()(Square *from, Square *to, GameState& gameState, bo
     if (!promotion)
         state.m_promotedPawnSquare = nullptr;
 
-    if (!isPawn && !state.m_captured)
-        state.m_noPawnMoveOrCapture ++;
+    if (!isPawn && capturedPiece == Pieces::Empty)
+        state.m_noPawnMoveOrCapture++;
     else
         state.m_noPawnMoveOrCapture = 0;
 


### PR DESCRIPTION
## Summary
- track captured pieces for white and black in `Controller`
- expose captured pieces to QML
- display captured pieces above and below the board
- refine restart logic and capture handling

## Testing
- `cmake ..` *(fails: Could not find Qt6Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6841bf11c8808333bcf188bc7ccbb758